### PR TITLE
Mostrar ventana en negro multitarea

### DIFF
--- a/.kotlin/errors/errors-1746285935147.log
+++ b/.kotlin/errors/errors-1746285935147.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/src/main/java/com/example/numbux/ControlActivity.kt
+++ b/app/src/main/java/com/example/numbux/ControlActivity.kt
@@ -49,7 +49,9 @@ class ControlActivity : ComponentActivity() {
                         val newVal = snapshot.getValue(Boolean::class.java) ?: false
                         remoteEnabled = newVal
                         // **Write into prefs so your service/UI everywhere picks it up**
-                        prefs.edit().putBoolean("blocking_enabled", newVal).apply()
+                        prefs.edit()
+                            .putBoolean("blocking_enabled", newVal)
+                            .commit()   // blocks until the value is written
                     }
                     override fun onCancelled(error: DatabaseError) { /* log if desired */ }
                 })

--- a/app/src/main/java/com/example/numbux/ControlActivity.kt
+++ b/app/src/main/java/com/example/numbux/ControlActivity.kt
@@ -1,62 +1,68 @@
 package com.example.numbux
 
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.database.ktx.database
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.ValueEventListener
-import com.google.firebase.ktx.Firebase
+import androidx.preference.PreferenceManager
 import com.example.numbux.ui.theme.NumbuxTheme
-import androidx.compose.material3.ExperimentalMaterial3Api
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.*
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
 
 @OptIn(ExperimentalMaterial3Api::class)
 class ControlActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // 1) Firebase anonymous auth + dbRef
+        // 1) Firebase anonymous auth + database reference
         Firebase.auth.signInAnonymously()
-
         val room = "testRoom"
-        // 1) Point the SDK at your live DB
-        val firebaseUrl = "https://numbux-790d6-default-rtdb.europe-west1.firebasedatabase.app"
-        val database = Firebase.database(firebaseUrl)
-
-        // 2) Reference your shared node
-        val dbRef = database
+        val firebaseUrl =
+            "https://numbux-790d6-default-rtdb.europe-west1.firebasedatabase.app"
+        val dbRef = Firebase
+            .database(firebaseUrl)
             .getReference("rooms")
             .child(room)
             .child("blocking_enabled")
 
-        // 2) Compose UI
         setContent {
+            val context = LocalContext.current
+            val prefs: SharedPreferences =
+                PreferenceManager.getDefaultSharedPreferences(context)
+
+            // Local UI state driven by remote DB
             var remoteEnabled by remember { mutableStateOf(false) }
 
-            // listen for remote changes
-            LaunchedEffect(Unit) {
-                dbRef.addValueEventListener(object: ValueEventListener {
-                    override fun onDataChange(snap: DataSnapshot) {
-                        remoteEnabled = snap.getValue(Boolean::class.java) ?: false
+            // Listen for remote changes and sync into SharedPreferences
+            LaunchedEffect(dbRef) {
+                dbRef.addValueEventListener(object : ValueEventListener {
+                    override fun onDataChange(snapshot: DataSnapshot) {
+                        val newVal = snapshot.getValue(Boolean::class.java) ?: false
+                        remoteEnabled = newVal
+                        // **Write into prefs so your service/UI everywhere picks it up**
+                        prefs.edit().putBoolean("blocking_enabled", newVal).apply()
                     }
-                    override fun onCancelled(err: DatabaseError) { /* log if you want */ }
+                    override fun onCancelled(error: DatabaseError) { /* log if desired */ }
                 })
             }
 
             NumbuxTheme {
-                Scaffold(topBar = { TopAppBar(title = { Text("Numbux Controller") }) }) { p ->
+                Scaffold(
+                    topBar = { TopAppBar(title = { Text("Numbux Controller") }) }
+                ) { padding ->
                     Row(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(p)
+                            .padding(padding)
                             .padding(24.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween
@@ -65,6 +71,7 @@ class ControlActivity : ComponentActivity() {
                         Switch(
                             checked = remoteEnabled,
                             onCheckedChange = { newVal ->
+                                // update remote
                                 dbRef.setValue(newVal)
                             }
                         )

--- a/app/src/main/java/com/example/numbux/MainActivity.kt
+++ b/app/src/main/java/com/example/numbux/MainActivity.kt
@@ -33,192 +33,110 @@ import com.google.firebase.ktx.Firebase
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.core.view.WindowCompat
 
+import android.content.SharedPreferences
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 
 
+
+@OptIn(ExperimentalMaterial3Api::class)
 class MainActivity : ComponentActivity() {
 
     companion object {
         private const val REQ_OVERLAY = 1001
     }
 
-    private fun isAccessibilityServiceEnabled(): Boolean {
-        val expected = ComponentName(this, AppBlockerService::class.java)
-            .flattenToString()
-        val enabled = Settings.Secure.getString(
-            contentResolver,
-            Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
-        ) ?: return false
+    private lateinit var prefs: SharedPreferences
+    private lateinit var blockingState: MutableState<Boolean>
+    private lateinit var prefListener: SharedPreferences.OnSharedPreferenceChangeListener
 
-        return TextUtils.SimpleStringSplitter(':')
-            .apply { setString(enabled) }
-            .any { it.equals(expected, ignoreCase = true) }
-    }
-
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // 1) Check overlay permission right away, *before* anything else
+        // 1) Overlay‐permission check (unchanged)…
         if (!Settings.canDrawOverlays(this)) {
-            Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                Uri.parse("package:$packageName")).also { intent ->
-                // start with a request code so we can catch the result
-                startActivityForResult(intent, REQ_OVERLAY)
-            }
-            // don’t finish() here—let onActivityResult fire when they're done
-            return
-        }
-
-        // 2) Now you know you have the overlay permission,
-        //    you can safely enable your blocker service, set up compose, etc.
-
-        // 1) Overlay & Accessibility checks
-        if (!Settings.canDrawOverlays(this)) {
-            startActivity(
-                Intent(
-                    Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                    Uri.parse("package:$packageName")
-                )
+            startActivityForResult(
+                Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:$packageName")),
+                REQ_OVERLAY
             )
-            finish()
             return
         }
 
-        BlockManager.setBlockedAppsExcept(
-            this,
-            listOf(packageName, "com.android.settings", "com.android.systemui")
-        )
+        // 2) Initialize SharedPreferences & Compose state
+        prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        blockingState = mutableStateOf(prefs.getBoolean("blocking_enabled", false))
 
-        if (!isAccessibilityServiceEnabled()) {
-            AlertDialog.Builder(this)
-                .setTitle("Activar Accesibilidad")
-                .setMessage(
-                    "Para que Numbux funcione correctamente, " +
-                            "ve a 'Apps instaladas'. Después 'Numbux' y actívalo."
-                )
-                .setPositiveButton("Entendido") { _, _ ->
-                    startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
-                }
-                .setCancelable(false)
-                .show()
+        // 3) Listen for external prefs changes
+        prefListener = SharedPreferences.OnSharedPreferenceChangeListener { sp, key ->
+            if (key == "blocking_enabled") {
+                // update our Compose state
+                blockingState.value = sp.getBoolean(key, false)
+            }
         }
+        prefs.registerOnSharedPreferenceChangeListener(prefListener)
 
-        // 2) Prefs & Firebase setup
-        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
-        val activity = this
-
-        Firebase.auth.signInAnonymously()
-
+        // 4) Firebase remote listener (unchanged)
         val room = "testRoom"
-        // 1) Point the SDK at your live DB
         val firebaseUrl = "https://numbux-790d6-default-rtdb.europe-west1.firebasedatabase.app"
-        val database = Firebase.database(firebaseUrl)
-
-        // 2) Reference your shared node
-        val dbRef = database
+        val dbRef = Firebase.database(firebaseUrl)
             .getReference("rooms")
             .child(room)
             .child("blocking_enabled")
 
-
-        // Host your Compose state here
-        val blockingState = mutableStateOf(
-            prefs.getBoolean("blocking_enabled", false)
-        )
-
-        // Listen for remote toggles
         dbRef.addValueEventListener(object : ValueEventListener {
             override fun onDataChange(snapshot: DataSnapshot) {
                 val remote = snapshot.getValue(Boolean::class.java) ?: false
+                // write to prefs *and* state – triggers our prefListener
                 prefs.edit().putBoolean("blocking_enabled", remote).apply()
-                blockingState.value = remote
             }
             override fun onCancelled(error: DatabaseError) {
                 Log.w("MainActivity", "Firebase listen failed", error.toException())
             }
         })
 
-        // 3) Compose UI
+        // 5) Now set up your Compose UI
         setContent {
-            // pull in our state
-            val blockingEnabled by blockingState
-
+            val enabled by blockingState
             NumbuxTheme {
-                Scaffold(
-                    topBar = {
-                        TopAppBar(title = { Text("Numbux") })
-                    }
-                ) { innerPadding ->
+                Scaffold(topBar = { TopAppBar(title = { Text("Numbux") }) }) { inner ->
                     Column(
-                        modifier = Modifier
+                        Modifier
                             .fillMaxSize()
-                            .padding(innerPadding)
+                            .padding(inner)
                             .padding(24.dp),
                         verticalArrangement = Arrangement.spacedBy(20.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        Text(
-                            "Bienvenido a Numbux",
-                            style = MaterialTheme.typography.headlineSmall
-                        )
+                        Text("Bienvenido a Numbux",
+                            style = MaterialTheme.typography.headlineSmall)
+
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text("Bloqueo de apps")
                             Spacer(Modifier.width(8.dp))
                             Switch(
-                                checked = blockingEnabled,
-                                onCheckedChange = { enabled ->
-                                    if (!enabled) {
-                                        // PIN-entry dialog
-                                        val pinInput = EditText(activity).apply {
-                                            inputType =
-                                                android.text.InputType
-                                                    .TYPE_CLASS_NUMBER or
-                                                        android.text.InputType
-                                                            .TYPE_NUMBER_VARIATION_PASSWORD
-                                            hint = "####"
-                                        }
-                                        AlertDialog.Builder(activity)
-                                            .setTitle("Ingrese PIN para desactivar")
-                                            .setView(pinInput)
-                                            .setPositiveButton("OK") { _, _ ->
-                                                val entered = pinInput.text.toString()
-                                                val correct = prefs
-                                                    .getString("pin_app_lock", "1234")
-                                                if (entered == correct) {
-                                                    // locally & remotely turn OFF
-                                                    blockingState.value = false
-                                                    prefs.edit()
-                                                        .putBoolean("blocking_enabled", false)
-                                                        .apply()
-                                                    dbRef.setValue(false)
-                                                } else {
-                                                    Toast
-                                                        .makeText(
-                                                            activity,
-                                                            "PIN incorrecto",
-                                                            Toast.LENGTH_SHORT
-                                                        )
-                                                        .show()
-                                                }
+                                checked = enabled,
+                                onCheckedChange = { isOn ->
+                                    if (!isOn) {
+                                        // ask PIN before disabling
+                                        showDisablePinDialog { success ->
+                                            if (success) {
+                                                // both local & remote
+                                                prefs.edit().putBoolean("blocking_enabled", false).apply()
+                                                dbRef.setValue(false)
                                             }
-                                            .setNegativeButton("Cancelar", null)
-                                            .show()
+                                        }
                                     } else {
-                                        // turn ON immediately
-                                        blockingState.value = true
-                                        prefs.edit()
-                                            .putBoolean("blocking_enabled", true)
-                                            .apply()
+                                        // enable immediately
+                                        prefs.edit().putBoolean("blocking_enabled", true).apply()
                                         dbRef.setValue(true)
                                     }
                                 }
                             )
                         }
+
                         Text(
-                            if (blockingEnabled)
-                                "El bloqueador está ACTIVADO"
-                            else
-                                "El bloqueador está DESACTIVADO",
+                            if (enabled) "El bloqueador está ACTIVADO"
+                            else "El bloqueador está DESACTIVADO",
                             style = MaterialTheme.typography.bodyMedium
                         )
                     }
@@ -227,19 +145,42 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun showDisablePinDialog(onResult: (Boolean) -> Unit) {
+        val pinInput = EditText(this).apply {
+            inputType = android.text.InputType.TYPE_CLASS_NUMBER or
+                    android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD
+            hint = "####"
+        }
+        AlertDialog.Builder(this)
+            .setTitle("Ingrese PIN para desactivar")
+            .setView(pinInput)
+            .setPositiveButton("OK") { _, _ ->
+                val entered = pinInput.text.toString()
+                val correct = prefs.getString("pin_app_lock", "1234")
+                if (entered == correct) onResult(true)
+                else {
+                    Toast.makeText(this, "PIN incorrecto", Toast.LENGTH_SHORT).show()
+                    onResult(false)
+                }
+            }
+            .setNegativeButton("Cancelar") { _, _ -> onResult(false) }
+            .show()
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == REQ_OVERLAY) {
-            if (Settings.canDrawOverlays(this)) {
-                // Great—permission granted. Restart onCreate logic:
-                recreate()
-            } else {
+            if (Settings.canDrawOverlays(this)) recreate()
+            else {
                 Toast.makeText(this,
-                    "Se necesita permiso para mostrar sobre otras apps",
-                    Toast.LENGTH_LONG).show()
-                finish()  // give up if they deny
+                    "Se necesita permiso para mostrar sobre otras apps", Toast.LENGTH_LONG).show()
+                finish()
             }
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        prefs.unregisterOnSharedPreferenceChangeListener(prefListener)
+    }
 }

--- a/app/src/main/java/com/example/numbux/accessibility/AppBlockerService.kt
+++ b/app/src/main/java/com/example/numbux/accessibility/AppBlockerService.kt
@@ -25,7 +25,8 @@ import android.graphics.Color
 import android.provider.Settings
 import android.net.Uri
 
-
+import android.view.Gravity
+import android.util.DisplayMetrics
 
 
 
@@ -77,7 +78,16 @@ class AppBlockerService : AccessibilityService() {
         // 3) Check overlay permission
         if (!Settings.canDrawOverlays(this)) return
 
-        // 4) Create & add the black view
+        // 4) Compute nav-bar height so we leave the bottom buttons exposed
+        val res = resources
+        val navBarResId = res.getIdentifier("navigation_bar_height", "dimen", "android")
+        val navBarHeight = if (navBarResId > 0) res.getDimensionPixelSize(navBarResId) else 0
+
+        // 5) Compute overlay height
+        val dm: DisplayMetrics = res.displayMetrics
+        val overlayHeight = dm.heightPixels - navBarHeight
+
+        // 6) Create & add the black view
         val wm = getSystemService(WINDOW_SERVICE) as WindowManager
         val overlay = View(this).apply {
             setBackgroundColor(Color.BLACK)
@@ -85,13 +95,16 @@ class AppBlockerService : AccessibilityService() {
         }
         val lp = LayoutParams(
             LayoutParams.MATCH_PARENT,
-            LayoutParams.MATCH_PARENT,
+            overlayHeight,
             WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
             LayoutParams.FLAG_NOT_FOCUSABLE
                     or LayoutParams.FLAG_LAYOUT_IN_SCREEN
                     or LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             PixelFormat.OPAQUE
-        )
+        ).apply {
+            gravity = Gravity.TOP
+        }
+
         wm.addView(overlay, lp)
         recentsOverlay = overlay
     }

--- a/app/src/main/java/com/example/numbux/accessibility/AppBlockerService.kt
+++ b/app/src/main/java/com/example/numbux/accessibility/AppBlockerService.kt
@@ -207,7 +207,6 @@ class AppBlockerService : AccessibilityService() {
         ) {
             Log.d("AppBlockerService","🔒 Blocking disable-accessibility dialog (cls=$cls)")
             blockAllTouchesFor(3_000)
-            performGlobalAction(GLOBAL_ACTION_BACK)
             startActivity(Intent(this, PinActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 putExtra("app_package", pkg)
@@ -243,7 +242,6 @@ class AppBlockerService : AccessibilityService() {
             && (type == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
                     || type == AccessibilityEvent.TYPE_WINDOWS_CHANGED)
         ) {
-            performGlobalAction(GLOBAL_ACTION_BACK)
             startActivity(Intent(this, PinActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 putExtra("app_package", pkg)

--- a/app/src/main/java/com/example/numbux/ui/PinActivity.kt
+++ b/app/src/main/java/com/example/numbux/ui/PinActivity.kt
@@ -86,7 +86,7 @@ class PinActivity : Activity() {
             finish()
         }
     }
-    
+
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         val pinLayout = findViewById<View>(R.id.pinLayoutRoot)
         if (pinLayout != null && ev != null) {
@@ -117,3 +117,4 @@ class PinActivity : Activity() {
         // disable back button
     }
 }
+

--- a/app/src/main/java/com/example/numbux/ui/PinActivity.kt
+++ b/app/src/main/java/com/example/numbux/ui/PinActivity.kt
@@ -1,6 +1,7 @@
 package com.example.numbux.ui
 
 import android.app.Activity
+import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Bundle
 import android.widget.Button
@@ -15,9 +16,7 @@ import com.example.numbux.R
 import com.example.numbux.control.BlockManager
 
 class PinActivity : Activity() {
-
     companion object {
-        // Packages requiring the fixed system PIN
         private val SYSTEM_PACKAGES = setOf(
             "com.android.packageinstaller",
             "com.google.android.packageinstaller",
@@ -27,50 +26,31 @@ class PinActivity : Activity() {
         private const val SYSTEM_PIN = "5678"
     }
 
+    private var targetPkg: String? = null
+    private lateinit var correctPin: String
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_pin)
 
-        // Obtain SharedPreferences
-        val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
-        // Get the package name we need to unlock
-        val targetPkg: String? = intent.getStringExtra("app_package")
+        // read the incoming target
+        targetPkg = intent.getStringExtra("app_package")
 
-        // Get the user-defined app-lock PIN (default 1234)
-        val appLockPin: String = prefs.getString("pin_app_lock", "1234") ?: "1234"
-        // Decide which PIN to validate
-        val correctPin: String = if (targetPkg != null && SYSTEM_PACKAGES.contains(targetPkg)) {
-            SYSTEM_PIN
-        } else {
-            appLockPin
-        }
+        // pick the right PIN
+        val appLockPin = PreferenceManager
+            .getDefaultSharedPreferences(this)
+            .getString("pin_app_lock", "1234") ?: "1234"
+        correctPin = if (targetPkg in SYSTEM_PACKAGES) SYSTEM_PIN else appLockPin
 
-        // Setup UI elements
-        val input = findViewById<EditText>(R.id.editTextPin)
-        val btn = findViewById<Button>(R.id.buttonUnlock)
-
-        btn.setOnClickListener {
-            if (input.text.toString() == correctPin) {
-                targetPkg?.let { pkg ->
-                    // Mark as temporarily allowed
-                    BlockManager.allowTemporarily(pkg)
-                    Toast.makeText(this, "Desbloqueado: $pkg", Toast.LENGTH_SHORT).show()
-                }
-                setResult(Activity.RESULT_OK)
-                BlockManager.isShowingPin = false
-
-                // only now do we “dismiss until the app changes”
-                intent.getStringExtra("app_package")?.let { pkg ->
-                    BlockManager.dismissUntilAppChanges(pkg)
-                }
-
-                finish()
+        findViewById<Button>(R.id.buttonUnlock).setOnClickListener {
+            if (findViewById<EditText>(R.id.editTextPin).text.toString() == correctPin) {
+                onPinCorrect()
             } else {
                 Toast.makeText(this, "PIN incorrecto", Toast.LENGTH_SHORT).show()
             }
         }
 
-        // Keep screen on and override lock
+        // keep screen on / show over lock
         window.addFlags(
             WindowManager.LayoutParams.FLAG_FULLSCREEN or
                     WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
@@ -80,6 +60,33 @@ class PinActivity : Activity() {
         )
     }
 
+    private fun onPinCorrect() {
+        // stop the service from re-showing PIN
+        BlockManager.isShowingPin = false
+
+        if (targetPkg != null && SYSTEM_PACKAGES.contains(targetPkg)) {
+            // SYSTEM flow covers both: uninstall *and* disable‐accessibility
+            // 1) allow that package once
+            BlockManager.allowTemporarily(targetPkg!!)
+            Toast.makeText(this, "Desbloqueado", Toast.LENGTH_SHORT).show()
+            // 2) simply dismiss the PIN screen—underneath stays the installer or the Settings dialog
+            finish()
+        } else if (targetPkg != null) {
+            // normal app‐lock flow
+            BlockManager.allowTemporarily(targetPkg!!)
+            Toast.makeText(this, "Desbloqueado: $targetPkg", Toast.LENGTH_SHORT).show()
+            setResult(Activity.RESULT_OK)
+            BlockManager.dismissUntilAppChanges(targetPkg!!)
+            packageManager.getLaunchIntentForPackage(targetPkg!!)?.also { launch ->
+                launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(launch)
+            }
+            finish()
+        } else {
+            finish()
+        }
+    }
+    
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         val pinLayout = findViewById<View>(R.id.pinLayoutRoot)
         if (pinLayout != null && ev != null) {

--- a/app/src/main/res/xml/accessibility_config.xml
+++ b/app/src/main/res/xml/accessibility_config.xml
@@ -4,6 +4,7 @@
     android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged|typeWindowsChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
     android:notificationTimeout="0"
-    android:accessibilityFlags="flagDefault"
+    android:accessibilityFlags="flagDefault|flagRequestFilterKeyEvents"
+    android:canRequestFilterKeyEvents="true"
     android:canRetrieveWindowContent="true"
     android:description="@string/accessibility_service_description" />


### PR DESCRIPTION
* Pide PIN para desinstalar todas las apps, quiero que solo se pregunte cuando es Numbux

* La pantalla del PIN aparece un pelín lenta cuando abro cualquier app

* Vuelvo a la app si pongo el pin correcto para accesibility y uninstall. 

La app SÍ HACE:
- Pide login para saber qué usuario eres.
- Si eres controller: solo boton para activar o desactivar

- Si eres estudiante:
- Salta notificacion que te redirige a accesibility.
- Venta dentro de la app que te lleva a accesibility.

- Boton controller y bloqueado sincronizados en todo momento.

- Cuando estoy dentro de una app y con bloqueo desactivado y turn on desde Controller, se bloquea la app.

- Si pongo el PIN la ventana desaparece y no vuelve a aparecer hasta el próximo ciclo (se resetea).

- Cuando intento desbloquear manualmente, pide el pin. También se desbloquea efectivamente.

- Con el bloqueo activo, se puede buscar en ajustes, en la lupa y se puede utilizar el teclado.

- Accesibility y Uninstall son independientes del botón.

- Impide la desactivación de privilegios de accesibility sin poner el pin y para desinstalar también. Luego ya se puede desinstalar.

- Cuando el botón está activo, aparece una pantalla negra en multitareas y se quita si te vas de multitarea.